### PR TITLE
Propagate malloc failure

### DIFF
--- a/dynarray.c
+++ b/dynarray.c
@@ -23,6 +23,7 @@ void *_dynarray_create(size_t init_cap, size_t stride)
     size_t header_size = DYNARRAY_FIELDS * sizeof(size_t);
     size_t arr_size = init_cap * stride;
     size_t *arr = (size_t *) malloc(header_size + arr_size);
+    if (arr == NULL) return NULL; // propagate failure
     arr[CAPACITY] = init_cap;
     arr[LENGTH] = 0;
     arr[STRIDE] = stride;
@@ -54,6 +55,7 @@ void *_dynarray_resize(void *arr)
         DYNARRAY_RESIZE_FACTOR * dynarray_capacity(arr),
         dynarray_stride(arr)
     );
+    if (temp == NULL) return NULL; // propagate failure
     memcpy(temp, arr, dynarray_length(arr) * dynarray_stride(arr)); // Copy erythin' over.
     _dynarray_field_set(temp, LENGTH, dynarray_length(arr)); // Set `length` field.
     _dynarray_destroy(arr); // Free previous array.

--- a/dynarray.c
+++ b/dynarray.c
@@ -18,6 +18,7 @@ To set the ith element of the array, use either bracket notation
 
 // Returns a pointer to the start of a new dynarray (after the header) which
 // has `init_cap` units of `stride` bytes.
+// If reallocation fails the function will return NULL.
 void *_dynarray_create(size_t init_cap, size_t stride)
 {
     size_t header_size = DYNARRAY_FIELDS * sizeof(size_t);
@@ -49,6 +50,7 @@ void _dynarray_field_set(void *arr, size_t field, size_t value)
 
 // Allocates a new dynarray with twice the size of the one passed in, and retaining
 // the values that the original stored.
+// If reallocation fails the function will return NULL.
 void *_dynarray_resize(void *arr)
 {
     void *temp = _dynarray_create( // Allocate new dynarray w/ more space.
@@ -62,6 +64,9 @@ void *_dynarray_resize(void *arr)
     return temp;
 }
 
+// Places a new value at the next available space.
+// If array is full then it will reallocate with a bigger size.
+// If reallocation fails the function will return NULL;
 void *_dynarray_push(void *arr, void *xptr)
 {
     if (dynarray_length(arr) >= dynarray_capacity(arr)) {

--- a/dynarray.c
+++ b/dynarray.c
@@ -64,8 +64,10 @@ void *_dynarray_resize(void *arr)
 
 void *_dynarray_push(void *arr, void *xptr)
 {
-    if (dynarray_length(arr) >= dynarray_capacity(arr))
+    if (dynarray_length(arr) >= dynarray_capacity(arr)) {
         arr = _dynarray_resize(arr);
+        if (arr == NULL) return NULL;
+    }
 
     memcpy(arr + dynarray_length(arr) * dynarray_stride(arr), xptr, dynarray_stride(arr));
     _dynarray_field_set(arr, LENGTH, dynarray_length(arr) + 1);


### PR DESCRIPTION
return `NULL` anytime memory is allocated or reallocated to alert user of library.