### PR TITLE
Replace _dynarray_field_{get, set} with _dynarray_field_at

### DIFF
--- a/dynarray.c
+++ b/dynarray.c
@@ -31,23 +31,6 @@ void *_dynarray_create(size_t init_cap, size_t stride)
     return (void *) (arr + DYNARRAY_FIELDS);
 }
 
-void _dynarray_destroy(void *arr)
-{
-    free(arr - DYNARRAY_FIELDS * sizeof(size_t));
-}
-
-// Returns the dynarray's field which is specified by passing
-// one of CAPACITY, LENGTH, STRIDE.
-size_t _dynarray_field_get(void *arr, size_t field)
-{
-    return ((size_t *)(arr) - DYNARRAY_FIELDS)[field];
-}
-
-void _dynarray_field_set(void *arr, size_t field, size_t value)
-{
-    ((size_t *)(arr) - DYNARRAY_FIELDS)[field] = value;
-}
-
 // Allocates a new dynarray with twice the size of the one passed in, and retaining
 // the values that the original stored.
 // If reallocation fails the function will return NULL.
@@ -57,10 +40,11 @@ void *_dynarray_resize(void *arr)
     size_t stride = dynarray_stride(arr);
     size_t header_size = DYNARRAY_FIELDS * sizeof(size_t);
     size_t arr_size = new_capacity * stride;
-    void *temp = realloc(arr - header_size, header_size + arr_size);
+    void *temp = realloc((arr) - header_size, header_size + arr_size);
     if (temp == NULL) return NULL; // propagate failure
     temp += header_size;
-    _dynarray_field_set(temp, DYNARRAY_CAPACITY_FIELD, new_capacity); // Set `capacity` field.
+    size_t *field_capacity = _dynarray_field_at(temp, DYNARRAY_CAPACITY_FIELD);
+    *field_capacity = new_capacity; 
     return temp;
 }
 
@@ -69,21 +53,27 @@ void *_dynarray_resize(void *arr)
 // If reallocation fails the function will return NULL;
 void *_dynarray_push(void *arr, void *xptr)
 {
+    if(arr == NULL || xptr == NULL) return NULL;
+
     if (dynarray_length(arr) >= dynarray_capacity(arr)) {
         arr = _dynarray_resize(arr);
         if (arr == NULL) return NULL;
     }
 
     memcpy(arr + dynarray_length(arr) * dynarray_stride(arr), xptr, dynarray_stride(arr));
-    _dynarray_field_set(arr, DYNARRAY_LENGTH_FIELD, dynarray_length(arr) + 1);
+    size_t *length_field = _dynarray_field_at(arr, DYNARRAY_LENGTH_FIELD);
+    *length_field += 1;
     return arr;
 }
 
 // Removes the last element in the array, but copies it to `*dest` first.
 void _dynarray_pop(void *arr, void *dest)
 {
+    if(arr == NULL || dest == NULL) return;
+
     memcpy(dest, arr + (dynarray_length(arr) - 1) * dynarray_stride(arr), dynarray_stride(arr));
-    _dynarray_field_set(arr, DYNARRAY_LENGTH_FIELD, dynarray_length(arr) - 1); // Decrement length.
+    size_t *length_field = _dynarray_field_at(arr, DYNARRAY_LENGTH_FIELD); // Decrement length.
+    *length_field -= 1;
 }
 
 

--- a/dynarray.h
+++ b/dynarray.h
@@ -19,11 +19,6 @@ enum dynarray_field_offset {
 };
 
 void *_dynarray_create(size_t length, size_t stride);
-void _dynarray_destroy(void *arr);
-
-size_t _dynarray_field_get(void *arr, size_t field);
-void _dynarray_field_set(void *arr, size_t field, size_t value);
-
 void *_dynarray_resize(void *arr);
 
 void *_dynarray_push(void *arr, void *xptr);
@@ -34,20 +29,31 @@ void _dynarray_pop(void *arr, void *dest);
 
 #define dynarray_create(type) _dynarray_create(DYNARRAY_DEFAULT_CAP, sizeof(type))
 #define dynarray_create_prealloc(type, capacity) _dynarray_create(capacity, sizeof(type))
-#define dynarray_destroy(arr) _dynarray_destroy(arr)
+#define dynarray_destroy(arr) \
+    do { \
+        if((arr) == NULL) break; \
+        free((void *)(arr) - DYNARRAY_FIELDS * sizeof(size_t)); \
+        (arr) = NULL; \
+    } while(0)
 
 #define dynarray_push(arr, x) arr = _dynarray_push(arr, &x)
 #define dynarray_push_rval(arr, x) \
     do { \
         __auto_type temp = x; \
-        arr = _dynarray_push(arr, &temp); \
+        (arr) = _dynarray_push(arr, &temp); \
     } while (0)
 
 #define dynarray_pop(arr, xptr) _dynarray_pop(arr, xptr)
 
-#define dynarray_capacity(arr) _dynarray_field_get(arr, DYNARRAY_CAPACITY_FIELD)
-#define dynarray_length(arr) _dynarray_field_get(arr, DYNARRAY_LENGTH_FIELD)
-#define dynarray_stride(arr) _dynarray_field_get(arr, DYNARRAY_STRIDE_FIELD)
+// Returns the dynarray's field which is specified by passing
+// one of CAPACITY, LENGTH, STRIDE. (getter/setter)
+#define _dynarray_field_at(arr, field_value) ((arr) == NULL || (field_value) >= DYNARRAY_FIELDS ? \
+                                            NULL: \
+                                            ((size_t *)(arr) - DYNARRAY_FIELDS) + (field_value))
+
+#define dynarray_capacity(arr) *_dynarray_field_at(arr, DYNARRAY_CAPACITY_FIELD)
+#define dynarray_length(arr) *_dynarray_field_at(arr, DYNARRAY_LENGTH_FIELD)
+#define dynarray_stride(arr) *_dynarray_field_at(arr, DYNARRAY_STRIDE_FIELD)
 
 #endif // DYNARRAY
 

--- a/makefile
+++ b/makefile
@@ -3,8 +3,8 @@ build: dynarray.o
 test: tests/tests.c dynarray.o
 	cp dynarray.o tests/
 	cp dynarray.h tests/
-	clang -g $^ -o out/tests
-	out/tests
+	clang -g $^ -o tests/out
+	tests/out
 
 dynarray.o: dynarray.c dynarray.h
 	clang -g -c dynarray.c -o dynarray.o

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -6,7 +6,6 @@
 int main()
 {
     int *v = dynarray_create(int);
-    
     assert_eq(dynarray_length(v), 0);
     assert_lte(dynarray_length(v), dynarray_capacity(v));
 
@@ -16,12 +15,13 @@ int main()
         assert_lte(dynarray_length(v), dynarray_capacity(v));
     }
 
-    for (int i = 0; i < dynarray_length(v); i++) {
-        printf("v[%d] -> %d\n", i, v[i]);
+    for (size_t i = 0; i < dynarray_length(v); i++) {
+        printf("v[%zu] -> %d\n", i, v[i]);
     }
 
     assert_eq(dynarray_length(v), 20);
     assert_lte(dynarray_length(v), dynarray_capacity(v));
 
     dynarray_destroy(v);
+    return 0;
 }


### PR DESCRIPTION
After reading issue #4, and after going through the code, I've implemented _dynarray_field_at. This macro yields a pointer to a specified a field or NULL if the aforementioned field is out of bounds. Furthermore, I've updated dynarray.c to make use of this new function.

Thank you for reviewing this PR, and I appreciate this useful library!