### PR TITLE
Added dynarray_get/set functionalities.

### DIFF
--- a/dynarray.c
+++ b/dynarray.c
@@ -249,7 +249,7 @@ const void *dynarray_get(void *arr, size_t index)
  * @param index Element index in the array.
  * @param new_value New value of the element at the given index (must be lvalue)
  * @return Pointer to the modified array element, or NULL if the operation fails.
- *
+ * @note The caller must ensure @p arr points to a valid memory location containing a dynamic array.
  */
 void *_dynarray_set(void *arr, size_t index, void *new_value)
 {

--- a/dynarray.c
+++ b/dynarray.c
@@ -1,4 +1,5 @@
 #include "dynarray.h"
+#include<stdio.h>
 
 /**
  * @file dynarray.h
@@ -229,4 +230,33 @@ void _dynarray_swap_remove(void *arr, size_t index, void *dest)
     _dynarray_field_set(arr, DYNARRAY_LENGTH_FIELD, arr_size - 1);
 }
 
+/**
+ * @brief Retrieves an element at a given index from a dynamic array
+ * @param arr Initialized dynamic array instance.
+ * @param index Index of an element to retrieve.
+ * @return Pointer to the array element, or NULL if the operation fails.
+ *
+ */
+const void *dynarray_get(void *arr, size_t index)
+{
+    if(arr == NULL || index > dynarray_length(arr)) return NULL;
+    return (void *)((char *)arr + index * dynarray_stride(arr));
+}
+
+/**
+ * @ingroup dynarray_internal
+ * @brief Modifies the value of an element at a given index in the dynamic array to a newly given value.
+ * @param arr Initialized dynamic array instance.
+ * @param index Element index in the array.
+ * @param new_value New value of the element at the given index (must be lvalue)
+ * @return Pointer to the modified array element, or NULL if the operation fails.
+ *
+ */
+void *_dynarray_set(void *arr, size_t index, void *new_value)
+{
+    const void *arr_field = dynarray_get(arr, index);
+    if(arr_field == NULL) return NULL;
+
+    return memcpy(arr + index, new_value, dynarray_stride(arr));
+}
 

--- a/dynarray.c
+++ b/dynarray.c
@@ -1,5 +1,4 @@
 #include "dynarray.h"
-#include<stdio.h>
 
 /**
  * @file dynarray.h

--- a/dynarray.c
+++ b/dynarray.c
@@ -230,15 +230,15 @@ void _dynarray_swap_remove(void *arr, size_t index, void *dest)
 }
 
 /**
- * @brief Retrieves an element at a given index from a dynamic array
+ * @brief Retrieves an element at a given index from a dynamic array.
  * @param arr Initialized dynamic array instance.
  * @param index Index of an element to retrieve.
  * @return Pointer to the array element, or NULL if the operation fails.
- *
+ * @note The caller must ensure @p arr points to a valid memory location containing a dynamic array.
  */
 const void *dynarray_get(void *arr, size_t index)
 {
-    if(arr == NULL || index > dynarray_length(arr)) return NULL;
+    if(index > dynarray_length(arr)) return NULL;
     return (void *)((char *)arr + index * dynarray_stride(arr));
 }
 

--- a/dynarray.c
+++ b/dynarray.c
@@ -256,6 +256,7 @@ void *_dynarray_set(void *arr, size_t index, void *new_value)
     const void *arr_field = dynarray_get(arr, index);
     if(arr_field == NULL) return NULL;
 
-    return memcpy(arr + index, new_value, dynarray_stride(arr));
+    size_t stride = dynarray_stride(arr);
+    return memcpy(arr + index * stride, new_value, stride);
 }
 

--- a/dynarray.h
+++ b/dynarray.h
@@ -83,6 +83,9 @@ void *_dynarray_push(void *arr, void *xptr);
 void _dynarray_pop(void *arr, void *dest);
 void _dynarray_swap_remove(void *arr, size_t index, void *dest);
 
+const void *dynarray_get(void *arr, size_t index);
+void *_dynarray_set(void *arr, size_t index, void *new_value);
+
 #define DYNARRAY_DEFAULT_CAP 1
 #define DYNARRAY_RESIZE_FACTOR 2
 
@@ -164,6 +167,23 @@ void _dynarray_swap_remove(void *arr, size_t index, void *dest);
         arr = _dynarray_push(arr, &temp); \
     } while (0)
 
+
+/**
+ * @brief Modifies the value of an element at a given index in the dynamic array to a newly given value.
+ * @param arr Initialized dynamic array instance.
+ * @param index Element index in the array.
+ * @param new_value New value of the element at the given index
+ * @return Pointer to the modified array element, or NULL if the operation fails.
+ */
+#define dynarray_set(arr, index, new_value) ({ \
+    void *_ret = NULL; \
+    __auto_type _new_value = (new_value); \
+    if(__builtin_types_compatible_p(__typeof__(*(arr)), __typeof__((new_value))) == 1) \
+    { \
+        _ret = _dynarray_set((arr), (index), &_new_value); \
+    } \
+    _ret; \
+})
 /**
  * @brief Removes the last element from the dynamic array.
  *

--- a/dynarray.h
+++ b/dynarray.h
@@ -167,23 +167,33 @@ void *_dynarray_set(void *arr, size_t index, void *new_value);
         arr = _dynarray_push(arr, &temp); \
     } while (0)
 
-
 /**
  * @brief Modifies the value of an element at a given index in the dynamic array to a newly given value.
  * @param arr Initialized dynamic array instance.
  * @param index Element index in the array.
- * @param new_value New value of the element at the given index
+ * @param new_value New value of the element at the given index, which is strictly an lvalue.
  * @return Pointer to the modified array element, or NULL if the operation fails.
+ * @note The caller must ensure @p arr points to a valid memory location containing a dynamic array.
  */
-#define dynarray_set(arr, index, new_value) ({ \
-    void *_ret = NULL; \
+#define dynarray_set(arr, index, new_value) _dynarray_set(arr, index, &new_value)
+
+/**
+ * @brief Modifies the value of an element at a given index in the dynamic array to a newly given value.
+ * Unlike dynarray_set, this macro accepts rvalues and arbitrary
+ * expressions, including literals, function calls, and computed values.
+ * @param arr Initialized dynamic array instance.
+ * @param index Element index in the array.
+ * @param new_value New value of the element at the given index.
+ * @return Pointer to the modified array element, or NULL if the operation fails.
+ * @note The caller must ensure @p arr points to a valid memory location containing a dynamic array.
+ */
+#define dynarray_set_rval(arr, index, new_value) ({ \
     __auto_type _new_value = (new_value); \
-    if(__builtin_types_compatible_p(__typeof__(*(arr)), __typeof__((new_value))) == 1) \
-    { \
-        _ret = _dynarray_set((arr), (index), &_new_value); \
-    } \
-    _ret; \
+    extern void dynarray_set_rval(void) __attribute__((error("Type of new_value does not match the type of the dynamic array elements"))); \
+    if (__builtin_types_compatible_p(__typeof__(*(arr)), __typeof__((new_value))) == 0) dynarray_set_rval(); \
+    _dynarray_set((arr), (index), &_new_value); \
 })
+
 /**
  * @brief Removes the last element from the dynamic array.
  *


### PR DESCRIPTION
I added two functions ```dynarray_get``` and ```dynarray_set``` as discussed in #4. 

 ```dynarray_set``` relies on compiler C extensions to handle the case where the ```new_value``` argument type does not match the type of elements in the dynamic array. Compiler extensions have also been used to handle the case of  ```new_value``` being an rvalue without having to split the function into ```dynarray_set``` and ```dynarray_set_rvalue```.

Thank you for your time.